### PR TITLE
Fixed "expecting dict; got: shell" error

### DIFF
--- a/ansible/roles/symfony/tasks/uglify.yml
+++ b/ansible/roles/symfony/tasks/uglify.yml
@@ -1,7 +1,6 @@
 ---
+- name: Install uglifyjs
+  shell: npm install -g uglify-js
 
-name: Install uglifyjs
-shell: npm install -g uglify-js
-
-name: Install uglifycss
-shell: npm install -g uglifycss
+- name: Install uglifycss
+  shell: npm install -g uglifycss


### PR DESCRIPTION
This commit fixes following error:
ERROR: expecting dict; got: shell, error in /Users/domagojgojak/OSS_Dev/ansible/roles/symfony/tasks/uglify.yml
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.

Error showed up during the first time boot process.